### PR TITLE
Utiliser la méthode getContext3d

### DIFF
--- a/libraries/learn_webgl/web/webgl_course_01_intro/00_minimal/main.dart
+++ b/libraries/learn_webgl/web/webgl_course_01_intro/00_minimal/main.dart
@@ -5,7 +5,7 @@ void main() {
   CanvasElement canvas = new CanvasElement();
   document.body.children.add(canvas);
 
-  webgl.RenderingContext gl = canvas.getContext("experimental-webgl") as webgl.RenderingContext;
+  webgl.RenderingContext gl = canvas.getContext3d();
 
   gl.clearColor(1.0, 0.0, 0.0, 1.0);
   gl.clear(webgl.COLOR_BUFFER_BIT);


### PR DESCRIPTION
La méthode getContext3d fait déjà le travail de checker le context `webgl` ou `experimental-webgl` et expose les options possibles de manière typée.